### PR TITLE
Mod FieldUtility.GetMediaUrl() to honor Media.AlwaysIncludeServerUrl

### DIFF
--- a/Source/Synthesis/Utility/FieldUtility.cs
+++ b/Source/Synthesis/Utility/FieldUtility.cs
@@ -29,7 +29,7 @@ namespace Synthesis.Utility
 
 			// the conditional here prevents URLs like /http://foo/bar from being generated if AlwaysIncludeServerUrl is enabled
 			// thanks to Dave Peterson for finding this.
-			return includeServerUrl ? HttpUtility.UrlPathEncode(MediaManager.GetMediaUrl(item)) : StringUtil.EnsurePrefix('/', HttpUtility.UrlPathEncode(MediaManager.GetMediaUrl(item)));
+			return includeServerUrl ? MediaManager.GetMediaUrl(item) : StringUtil.EnsurePrefix('/', HttpUtility.UrlPathEncode(MediaManager.GetMediaUrl(item)));
 		}
 
 		/// <summary>

--- a/Source/Synthesis/Utility/FieldUtility.cs
+++ b/Source/Synthesis/Utility/FieldUtility.cs
@@ -18,9 +18,18 @@ namespace Synthesis.Utility
 		{
 			Assert.ArgumentNotNull(item, "item");
 
+			// If Media.AlwaysIncludeServerUrl is set, it should override the LinkManager setting for
+            // media links.
+		    bool includeServerUrl = LinkManager.Provider.AlwaysIncludeServerUrl;
+		    string mediaAlwaysIncludeServerUrl = Sitecore.Configuration.Settings.GetSetting("Media.AlwaysIncludeServerUrl", string.Empty);
+		    if (!string.IsNullOrEmpty(mediaAlwaysIncludeServerUrl))
+		    {
+		        includeServerUrl = (mediaAlwaysIncludeServerUrl.ToLower() == "true");
+		    }
+
 			// the conditional here prevents URLs like /http://foo/bar from being generated if AlwaysIncludeServerUrl is enabled
 			// thanks to Dave Peterson for finding this.
-			return LinkManager.Provider.AlwaysIncludeServerUrl ? MediaManager.GetMediaUrl(item) : StringUtil.EnsurePrefix('/', MediaManager.GetMediaUrl(item));
+			return includeServerUrl ? HttpUtility.UrlPathEncode(MediaManager.GetMediaUrl(item)) : StringUtil.EnsurePrefix('/', HttpUtility.UrlPathEncode(MediaManager.GetMediaUrl(item)));
 		}
 
 		/// <summary>

--- a/Source/Synthesis/Utility/FieldUtility.cs
+++ b/Source/Synthesis/Utility/FieldUtility.cs
@@ -16,15 +16,15 @@ namespace Synthesis.Utility
 		/// </summary>
 		public static string GetMediaUrl(MediaItem item)
 		{
-		    Assert.ArgumentNotNull(item, "item");
+			Assert.ArgumentNotNull(item, "item");
 
-		    // If Media.AlwaysIncludeServerUrl is set, it should override the LinkManager setting for media links.
-		    bool includeServerUrl = LinkManager.Provider.AlwaysIncludeServerUrl;
-		    string mediaAlwaysIncludeServerUrl = Sitecore.Configuration.Settings.GetSetting("Media.AlwaysIncludeServerUrl", string.Empty);
-		    if (!string.IsNullOrEmpty(mediaAlwaysIncludeServerUrl))
-		    {
-		        includeServerUrl = (mediaAlwaysIncludeServerUrl.ToLower() == "true");
-		    }
+			// If Media.AlwaysIncludeServerUrl is set, it should override the LinkManager setting for media links.
+			bool includeServerUrl = LinkManager.Provider.AlwaysIncludeServerUrl;
+			string mediaAlwaysIncludeServerUrl = Sitecore.Configuration.Settings.GetSetting("Media.AlwaysIncludeServerUrl", string.Empty);
+			if (!string.IsNullOrEmpty(mediaAlwaysIncludeServerUrl))
+			{
+				includeServerUrl = (mediaAlwaysIncludeServerUrl.ToLower() == "true");
+			}
 
 			// the conditional here prevents URLs like /http://foo/bar from being generated if AlwaysIncludeServerUrl is enabled
 			// thanks to Dave Peterson for finding this.

--- a/Source/Synthesis/Utility/FieldUtility.cs
+++ b/Source/Synthesis/Utility/FieldUtility.cs
@@ -16,10 +16,9 @@ namespace Synthesis.Utility
 		/// </summary>
 		public static string GetMediaUrl(MediaItem item)
 		{
-			Assert.ArgumentNotNull(item, "item");
+		    Assert.ArgumentNotNull(item, "item");
 
-			// If Media.AlwaysIncludeServerUrl is set, it should override the LinkManager setting for
-            // media links.
+		    // If Media.AlwaysIncludeServerUrl is set, it should override the LinkManager setting for media links.
 		    bool includeServerUrl = LinkManager.Provider.AlwaysIncludeServerUrl;
 		    string mediaAlwaysIncludeServerUrl = Sitecore.Configuration.Settings.GetSetting("Media.AlwaysIncludeServerUrl", string.Empty);
 		    if (!string.IsNullOrEmpty(mediaAlwaysIncludeServerUrl))


### PR DESCRIPTION
Modified FieldUtility.GetMediaUrl() to honor the Media.AlwaysIncludeServerUrl setting, if it is set. (Issue #13) 