### PR TITLE
Fixes GetPreviousSibling Implementation

### DIFF
--- a/Source/Synthesis/FieldTypes/Adapters/AxesAdapter.cs
+++ b/Source/Synthesis/FieldTypes/Adapters/AxesAdapter.cs
@@ -65,7 +65,7 @@ namespace Synthesis.FieldTypes.Adapters
 		[SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Following Sitecore Axes naming")]
 		public IStandardTemplateItem GetPreviousSibling()
 		{
-			return _axes.GetNextSibling().AsStronglyTyped();
+			return _axes.GetPreviousSibling().AsStronglyTyped();
 		}
 
 		public bool IsAncestorOf(IStandardTemplateItem item)


### PR DESCRIPTION
Hi,
I found this while using Synthesis today, that next- and prev-sibling of AxesAdapter always returned the next, Instead of making an issue, I thought I'd just submit a PR instead. 

I haven't executed your tests yet, so you might want to change something connected to that as well (?) (I use synthesis to be able to test sitecore, so I'd imagine that it is a bit tricky to test :smile:)