### PR TITLE
Expose the NameValueCollection of DictionaryField

### DIFF
--- a/Source/Synthesis/FieldTypes/DictionaryField.cs
+++ b/Source/Synthesis/FieldTypes/DictionaryField.cs
@@ -27,7 +27,7 @@ namespace Synthesis.FieldTypes
 		/// <summary>
 		/// Gets the keys and values in the field
 		/// </summary>
-		protected virtual NameValueCollection Values
+		public virtual NameValueCollection Values
 		{
 			get
 			{


### PR DESCRIPTION
Hi,
We were using a Dictionary field and wanted to enumerate the name-values. But since the collection is protected you are not allowed to. 

This PR just makes the property `Values` public