### PR TITLE
Adding Solr support to Synthesis

### DIFF
--- a/Source/Synthesis.Solr/ContentSearch/SynthesisLinqToSolrIndex.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisLinqToSolrIndex.cs
@@ -1,0 +1,53 @@
+﻿using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.Linq.Solr;
+using Sitecore.ContentSearch.SolrProvider;
+using SolrNet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace Synthesis.Solr.ContentSearch
+{
+	class SynthesisLinqToSolrIndex<T> : Sitecore.ContentSearch.SolrProvider.LinqToSolrIndex<T>
+	{
+		private readonly FieldNameTranslator _fieldNameTranslator;
+		private SolrSearchContext _context;
+		public SynthesisLinqToSolrIndex(SolrSearchContext context) : this(context, null)
+		{
+		}
+		public SynthesisLinqToSolrIndex(SolrSearchContext context, params IExecutionContext[] executionContexts)
+			: base(context, executionContexts)
+		{
+			_fieldNameTranslator = new SynthesisSolrFieldNameTranslator(context);
+			_context = context;
+		}
+		protected override FieldNameTranslator FieldNameTranslator
+		{
+			get { return _fieldNameTranslator; }
+		}
+		/*
+		 * THIS METHOD IS A TOTAL HACK
+		 * They exist to work around a bug in Sitecore (7.x-8.0 at least) where it uses private reflection
+		 * in such a way that it breaks all derived classes of LinqToSolrIndex when the solr query is mapped
+		 * in a particular way, such as when using a database name in your search query.
+		 * 
+		 * These basically act as proxies so the private reflection in Sitecore hits these methods,
+		 * which then reflect the call down to the base class' private method as is expected.
+		 * 
+		 * Source of hack: the Execute() method on the base class doing this:
+		 * MethodInfo methodInfo = this.GetType().GetMethod("ApplyScalarMethods", BindingFlags.Instance | BindingFlags.NonPublic).MakeGenericMethod(typeof (TResult), resultType);
+		 * 
+		 * The this.GetType() cause it to look for the private methods on any derived classes, where they do not exist.
+		 */
+		private TResult ApplyScalarMethods<TResult, TDocument>(SolrCompositeQuery compositeQuery, object processedResults, SolrQueryResults<Dictionary<string, object>> results)
+		{
+			var baseMethod = typeof(Sitecore.ContentSearch.SolrProvider.LinqToSolrIndex<T>).GetMethod("ApplyScalarMethods", BindingFlags.Instance | BindingFlags.NonPublic).MakeGenericMethod(typeof(TResult), typeof(TDocument));
+
+			return (TResult)baseMethod.Invoke(this, new object[] { compositeQuery, processedResults, results });
+		}
+	}
+}

--- a/Source/Synthesis.Solr/ContentSearch/SynthesisSolrDocumentTypeMapper.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisSolrDocumentTypeMapper.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Sitecore.ContentSearch.SolrProvider.Mapping;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.Linq.Methods;
+using Sitecore.ContentSearch.Security;
+using Sitecore.Diagnostics;
+using Synthesis.ContentSearch;
+using System.Collections;
+
+namespace Synthesis.Solr.ContentSearch
+{
+	class SynthesisSolrDocumentTypeMapper : SolrDocumentPropertyMapper
+	{
+		private readonly SynthesisDocumentTypeMapper _synthesisMapper = new SynthesisDocumentTypeMapper();
+		protected override object CreateElementInstance(System.Type baseType, IDictionary<string, object> fieldValues, IEnumerable<IExecutionContext> executionContexts)
+		{
+			return base.CreateElementInstance(baseType, fieldValues, executionContexts);
+		}
+
+		public override TElement MapToType<TElement>(Dictionary<string, object> document, SelectMethod selectMethod, IEnumerable<IFieldQueryTranslator> virtualFieldProcessors, IEnumerable<IExecutionContext> executionContexts, SearchSecurityOptions securityOptions)
+		{
+			if (document.ContainsKey("__smallupdateddate_tdt") && !document.ContainsKey("__smallupdateddate"))
+			{
+				document["__smallupdateddate"] = document["__smallupdateddate_tdt"];
+				document.Remove("__smallupdateddate_tdt");
+			}
+			var mappingResult = _synthesisMapper.MapToType<TElement>(() => ExtractFieldsFromDocument(document, virtualFieldProcessors), selectMethod);
+
+			// if the result type is not IStandardTemplateItem, use the default functionality
+			if (!mappingResult.MappedSuccessfully)
+				return base.MapToType<TElement>(document, selectMethod, virtualFieldProcessors, executionContexts, securityOptions);
+
+			return mappingResult.Document;
+		}
+
+		private Dictionary<string, string> ExtractFieldsFromDocument(IDictionary<string, object> document, IEnumerable<IFieldQueryTranslator> virtualFieldProcessors)
+		{
+			Assert.ArgumentNotNull(document, "document");
+			if (virtualFieldProcessors != null)
+				document = virtualFieldProcessors.Aggregate(document, (current, processor) => processor.TranslateFieldResult(current, index.FieldNameTranslator));
+
+			return document.ToDictionary(x => x.Key, x => ObjectToString(x.Value));
+		}
+		private static string ObjectToString(object value)
+		{
+			if (value is ArrayList)
+			{
+				return string.Join("|", from object obj in (ArrayList)value select obj);
+			}
+			return value.ToString();
+		}
+
+	}
+}

--- a/Source/Synthesis.Solr/ContentSearch/SynthesisSolrFieldNameTranslator.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisSolrFieldNameTranslator.cs
@@ -1,0 +1,91 @@
+﻿using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.SolrProvider;
+using Sitecore.Data;
+using Sitecore.Globalization;
+using Synthesis.FieldTypes.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Synthesis.Solr.ContentSearch
+{
+	class SynthesisSolrFieldNameTranslator : FieldNameTranslator
+	{
+		private SolrSearchContext _context;
+
+		public SynthesisSolrFieldNameTranslator(SolrSearchContext context)
+		{
+			this._context = context;
+		}
+		/// <summary>
+		/// The field mapper wants to append methods onto the SOLR field (I.E. _temlate.rawvalue) by returning null in the member method
+		/// below for the raw value method and removing the dot here we can correct this behavior
+		/// </summary>
+		/// <param name="fieldName">The name of the solr field thus far in the process</param>
+		/// <returns>solr field name</returns>
+		public override string GetIndexFieldName(string fieldName)
+		{
+			if (fieldName.EndsWith("."))
+				return fieldName.Remove(fieldName.Length - 1);
+			if (_context.Index.Schema.AllFieldNames.Where(x => x == fieldName).Any())
+				return fieldName;
+			fieldName = AppendSolrText(fieldName);
+			return fieldName;
+		}
+
+
+		/// <summary>
+		/// Take the property from a synthesis member and translate that into a solr field
+		/// </summary>
+		/// <param name="member">Class member that corresponds to a synthesis object property</param>
+		/// <returns>solr field name</returns>
+		public override string GetIndexFieldName(MemberInfo member)
+		{
+			if (!member.CustomAttributes.Any() || !member.CustomAttributes.Where(a => a.AttributeType == typeof(Sitecore.ContentSearch.IndexFieldAttribute)).Any())
+				return null;
+			var attributes = member.CustomAttributes.Where(a => a.AttributeType == typeof(Sitecore.ContentSearch.IndexFieldAttribute));
+			if (!attributes.Any())
+				return null;
+			var fieldName = attributes.First().ConstructorArguments.First().Value.ToString();
+			if (_context.Index.Schema.AllFieldNames.Where(x => x == fieldName).Any())
+				return fieldName;
+			Type type = ((PropertyInfo)member).PropertyType;
+			if (typeof(ITextField).IsAssignableFrom(type)
+				|| typeof(IHyperlinkField).IsAssignableFrom(type)
+				|| typeof(string).IsAssignableFrom(type))
+				AppendSolrText(fieldName);
+			else if (typeof(IBooleanField).IsAssignableFrom(type)
+				|| typeof(bool).IsAssignableFrom(type))
+				fieldName += "_b";
+			else if (typeof(IItemReferenceListField).IsAssignableFrom(type)
+				|| typeof(IDictionaryField).IsAssignableFrom(type)
+				|| typeof(ID[]).IsAssignableFrom(type))
+				fieldName += "_sm";
+			else if (typeof(IDateTimeField).IsAssignableFrom(type)
+				|| typeof(DateTime).IsAssignableFrom(type))
+				fieldName += "_tdt";
+			else if (typeof(IIntegerField).IsAssignableFrom(type)
+				|| typeof(int).IsAssignableFrom(type))
+				fieldName += "_i";
+			return fieldName;
+		}
+		/// <summary>
+		/// If the context is a foreign language we should use the foreign language text solr fields
+		/// </summary>
+		/// <param name="fieldName">the initial field name</param>
+		/// <returns>field name with a dynamic field identifier on it</returns>
+		private string AppendSolrText(string fieldName)
+		{
+			if (Sitecore.Context.Site == null || Sitecore.Context.Language.Name == Sitecore.Context.Site.Language)
+				fieldName += "_t";
+			else
+				fieldName += "_t_" + Sitecore.Context.Language;
+			return fieldName;
+		}
+	}
+}

--- a/Source/Synthesis.Solr/ContentSearchExtensions.cs
+++ b/Source/Synthesis.Solr/ContentSearchExtensions.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Diagnostics;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.Utilities;
+using Sitecore.Data;
+using Sitecore.Data.Items;
+using Sitecore.Exceptions;
+using Synthesis.ContentSearch.Lucene;
+using Synthesis.Synchronization;
+using Sitecore.ContentSearch.SolrProvider;
+using Synthesis.Solr.ContentSearch;
+using Sitecore.ContentSearch.Linq.Parsing;
+using Sitecore.ContentSearch.Linq.Solr;
+
+namespace Synthesis.Solr
+{
+	public static class ContentSearchExtensions
+	{
+		/// <summary>
+		/// Gets a queryable for Synthesis items (supports querying on interfaces, unlike the standard method)
+		/// </summary>
+		/// <typeparam name="TResult">The type of the result item to bind to.</typeparam>
+		/// <param name="context">The search context to use</param>
+		/// <returns>A queryable item that standard Sitecore LINQ can be used on</returns>
+		public static IQueryable<TResult> GetSolrSynthesisQueryable<TResult>(this IProviderSearchContext context)
+			where TResult : IStandardTemplateItem
+		{
+			return GetSolrSynthesisQueryable<TResult>(context, true);
+		}
+
+		/// <summary>
+		/// Gets a queryable for Synthesis items (supports querying on interfaces, unlike the standard method)
+		/// </summary>
+		/// <typeparam name="TResult">The type of the result item to bind to.</typeparam>
+		/// <param name="context">The search context to use</param>
+		/// <param name="applyStandardFilters">Controls whether results will be auto-filtered to context language, correct template, and latest version</param>
+		/// <returns>A queryable item that standard Sitecore LINQ can be used on</returns>
+		public static IQueryable<TResult> GetSolrSynthesisQueryable<TResult>(this IProviderSearchContext context, bool applyStandardFilters)
+			where TResult : IStandardTemplateItem
+		{
+			return GetSolrSynthesisQueryable<TResult>(context, applyStandardFilters, null);
+		}
+		/// <summary>
+		/// Gets a queryable for Synthesis items
+		/// </summary>
+		/// <typeparam name="TResult">The type of the result item to bind to.</typeparam>
+		/// <param name="context">The search context to use</param>
+		/// <param name="applyStandardFilters">Controls whether results will be auto-filtered to context language, correct template, and latest version</param>
+		/// <param name="executionContext">The execution context to run the query under</param>
+		/// <returns>A queryable item that standard Sitecore LINQ can be used on</returns>
+		public static IQueryable<TResult> GetSolrSynthesisQueryable<TResult>(this IProviderSearchContext context, bool applyStandardFilters, params IExecutionContext[] executionContext)
+			where TResult : IStandardTemplateItem
+		{
+			IQueryable<TResult> queryable;
+			var solrContext = context as SolrSearchContext;
+			if (solrContext != null)
+			{
+				var overrideMapper = new SynthesisSolrDocumentTypeMapper();
+				overrideMapper.Initialize(context.Index);
+				var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Dictionary<string,object>>>(overrideMapper);
+				var executionContexts = new List<IExecutionContext>();
+				if (executionContext != null) executionContexts.AddRange(executionContext);
+				executionContexts.Add(mapperExecutionContext);
+
+				queryable = GetSolrQueryable<TResult>(solrContext, executionContexts.ToArray());
+			}
+			else
+				throw new NotImplementedException("This method is only applicable to a SOLR query context.");
+			if (applyStandardFilters) queryable = queryable.ApplyStandardFilters();
+
+			return queryable;
+		}
+		private static IQueryable<TResult> GetSolrQueryable<TResult>(SolrSearchContext context, IExecutionContext[] executionContext)
+			where TResult : IStandardTemplateItem
+		{
+			var linqToSolrIndex = new SynthesisLinqToSolrIndex<TResult>(context, executionContext);
+			
+			if (context.Index.Locator.GetInstance<IContentSearchConfigurationSettings>().EnableSearchDebug())
+				((IHasTraceWriter)linqToSolrIndex).TraceWriter = new LoggingTraceWriter(SearchLog.Log);
+			return linqToSolrIndex.GetQueryable();
+		}
+	}
+}

--- a/Source/Synthesis.Solr/Properties/AssemblyInfo.cs
+++ b/Source/Synthesis.Solr/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Synthesis.Solr")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Synthesis.Solr")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("Sitecore.ContentSearch.SolrProvider")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c86979b6-3b97-48d9-91a4-d962c9e4890b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Synthesis.Solr/Synthesis.Solr.csproj
+++ b/Source/Synthesis.Solr/Synthesis.Solr.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Synthesis.Solr</RootNamespace>
+    <AssemblyName>Synthesis.Solr</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Practices.ServiceLocation">
+      <HintPath>..\..\..\..\inetpub\wwwroot\Spectrum\Source\Spectrum.Web\bin\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch">
+      <HintPath>..\..\..\inetpub\wwwroot\Spectrum\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch.Linq">
+      <HintPath>..\..\..\inetpub\wwwroot\Spectrum\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch.Linq.Solr">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.Linq.Solr.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch.SolrProvider">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.SolrProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Kernel">
+      <HintPath>..\..\..\inetpub\wwwroot\Spectrum\Dependencies\Libraries\Sitecore\Sitecore.Kernel.dll</HintPath>
+    </Reference>
+    <Reference Include="SolrNet">
+      <HintPath>..\Dependencies\Libraries\Sitecore\SolrNet.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ContentSearchExtensions.cs" />
+    <Compile Include="ContentSearch\SynthesisLinqToSolrIndex.cs" />
+    <Compile Include="ContentSearch\SynthesisSolrDocumentTypeMapper.cs" />
+    <Compile Include="ContentSearch\SynthesisSolrFieldNameTranslator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Synthesis\Synthesis.csproj">
+      <Project>{ebae2c10-079d-4eb1-9e46-82cec35d7f4b}</Project>
+      <Name>Synthesis</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Synthesis.Tests/Fixtures/ContentSearch/ContentSearchQueryExtensionTests.cs
+++ b/Source/Synthesis.Tests/Fixtures/ContentSearch/ContentSearchQueryExtensionTests.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using NUnit.Framework;
 using Sitecore;
+using Sitecore.ContentSearch.LuceneProvider;
+using Synthesis.Solr;
 
 namespace Synthesis.Tests.Fixtures.ContentSearch
 {
@@ -20,7 +22,7 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 		{
 			using (var context = CreateTestSearchContext())
 			{
-				var query = context.GetSynthesisQueryable<IStandardTemplateItem>()
+				var query = ResolveSynthesisQueryable(context)
 					.ContainsOr(x => x.TemplateIds, new[] { TemplateIDs.Sublayout, TemplateIDs.WorkflowState })
 					.ToArray();
 
@@ -30,13 +32,14 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 			}
 		}
 
+
 		[Test]
 		public void ContentSearch_FindsSecurityFolderOrRenderingOptions_WhenContainsOrIsUsed()
 		{
 			using (var context = CreateTestSearchContext())
 			{
 				var listOfNames = new List<string> {"Security folder", "Rendering Options"};
-				var query = context.GetSynthesisQueryable<IStandardTemplateItem>()
+				var query = ResolveSynthesisQueryable(context)
 					.ContainsOr(x => x.Name, listOfNames)
 					.ToArray();
 
@@ -44,6 +47,13 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 				Assert.IsTrue(query.Any(x => x.Name == listOfNames[0]), "ContainsOr result contained no security folder item");
 				Assert.IsTrue(query.Any(x => x.Name == listOfNames[1]), "ContainsOr result contained no rendering options item");
 			}
+		}
+
+		private static IQueryable<IStandardTemplateItem> ResolveSynthesisQueryable(Sitecore.ContentSearch.IProviderSearchContext context)
+		{
+			if (context is LuceneSearchContext)
+				return context.GetSynthesisQueryable<IStandardTemplateItem>();
+			return context.GetSolrSynthesisQueryable<IStandardTemplateItem>();
 		}
 	}
 }

--- a/Source/Synthesis.Tests/Fixtures/ContentSearch/FieldTypeTests.cs
+++ b/Source/Synthesis.Tests/Fixtures/ContentSearch/FieldTypeTests.cs
@@ -4,6 +4,8 @@ using NUnit.Framework;
 using Sitecore;
 using Sitecore.ContentSearch.Linq;
 using Synthesis.Tests.Fixtures.ContentSearch.Data;
+using Synthesis.Solr;
+using Sitecore.ContentSearch.LuceneProvider;
 
 namespace Synthesis.Tests.Fixtures.ContentSearch
 {
@@ -138,7 +140,7 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 				Assert.IsTrue(facets.Categories.Count > 0, "No valid facets found");
 				Assert.IsTrue(facets.Categories.First().Values.Count > 0, "No valid facet values found");
 
-				Assert.IsTrue(facets.Categories.SelectMany(x => x.Values).All(x => x.Name.StartsWith("T", StringComparison.OrdinalIgnoreCase)), "Facets had items without the specified text value!");
+				Assert.IsTrue(facets.Categories.SelectMany(x => x.Values).All(x => x.Name.StartsWith("T", StringComparison.OrdinalIgnoreCase) || x.AggregateCount == 0), "Facets had items without the specified text value!");
 			});
 		}
 
@@ -148,7 +150,10 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 			{
 				using (new InitializerForcer(new SearchTemplateItemInitializer()))
 				{
-					testBody(context.GetSynthesisQueryable<ISearchTemplateItem>(useStandardFilters));
+					if (context is LuceneSearchContext)
+						testBody(context.GetSynthesisQueryable<ISearchTemplateItem>(useStandardFilters));
+					else
+						testBody(context.GetSolrSynthesisQueryable<ISearchTemplateItem>(useStandardFilters));
 				}
 			}
 		}

--- a/Source/Synthesis.Tests/Synthesis.Tests.csproj
+++ b/Source/Synthesis.Tests/Synthesis.Tests.csproj
@@ -48,6 +48,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.ContentSearch.LuceneProvider, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.LuceneProvider.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Kernel">
       <HintPath>..\..\Dependencies\Libraries\Sitecore\Sitecore.Kernel.dll</HintPath>
     </Reference>
@@ -95,6 +99,10 @@
     <Compile Include="Utility\FieldTestTemplateCreator.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Synthesis.Solr\Synthesis.Solr.csproj">
+      <Project>{d76ce576-81d7-4bda-b6eb-7e5b72c0bcc5}</Project>
+      <Name>Synthesis.Solr</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Synthesis\Synthesis.csproj">
       <Project>{EBAE2C10-079D-4EB1-9E46-82CEC35D7F4B}</Project>
       <Name>Synthesis</Name>

--- a/Source/Synthesis/ContentSearchExtensions.cs
+++ b/Source/Synthesis/ContentSearchExtensions.cs
@@ -72,8 +72,7 @@ namespace Synthesis
 			}
 			else
 			{
-				// TODO: possible SOLR support with different mapper
-				throw new NotImplementedException("At this time Synthesis only supports Lucene indexes.");
+				throw new NotImplementedException("Use GetSolrSynthesisQueryable in Synthesis.Solr to utilize SOLR indexes.");
 			}
 
 			if (applyStandardFilters) queryable = queryable.ApplyStandardFilters();

--- a/Source/Synthesis/FieldTypes/DateTimeField.cs
+++ b/Source/Synthesis/FieldTypes/DateTimeField.cs
@@ -21,9 +21,10 @@ namespace Synthesis.FieldTypes
 			{
 				if (!IsFieldLoaded && InnerSearchValue != null)
 				{
-					var converter = new IndexFieldDateTimeValueConverter();
-					// ReSharper disable once PossibleNullReferenceException
-					return (DateTime)converter.ConvertFrom(InnerSearchValue);
+					//var converter = new IndexFieldDateTimeValueConverter();
+					//// ReSharper disable once PossibleNullReferenceException
+					//return (DateTime)converter.ConvertFrom(InnerSearchValue);
+					return DateTime.Parse(InnerSearchValue);
 				}
 
 				return ((DateField)InnerField).DateTime;

--- a/Synthesis.sln
+++ b/Synthesis.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthesis.Testing", "Source
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthesis.Mvc", "Source\Synthesis.Mvc\Synthesis.Mvc.csproj", "{97C803D2-5E32-4D5C-8ECB-EE49D759A953}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthesis.Solr", "Source\Synthesis.Solr\Synthesis.Solr.csproj", "{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{97C803D2-5E32-4D5C-8ECB-EE49D759A953}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97C803D2-5E32-4D5C-8ECB-EE49D759A953}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97C803D2-5E32-4D5C-8ECB-EE49D759A953}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
essentially copied the  Lucene functionality with a few distinct changes in how the documents are managed.  This was done in a seperate Synthesis.Solr project to avoid a dependency on solr in the main area of Synthesis.  Additionally I've modified the search unit tests so that Lucene and Solr share tests.  I believe there are differences in how sitecore sets up the fields in Solr vs Lucene, so some of the unit tests are failing due to unexpected results.  Also i changed how the search DateTimeField is acquired since the unit tests were throwing exceptions, this will need review.