### PR TITLE
Item type check in InheritedTemplates computed index field

### DIFF
--- a/Source/Synthesis/ContentSearch/ComputedFields/InheritedTemplates.cs
+++ b/Source/Synthesis/ContentSearch/ComputedFields/InheritedTemplates.cs
@@ -25,13 +25,19 @@ namespace Synthesis.ContentSearch.ComputedFields
 
 		public object ComputeFieldValue(IIndexable indexable)
 		{
-			return GetAllTemplates(indexable as SitecoreIndexableItem);
+            Assert.ArgumentNotNull(indexable, "indexable");
+            return GetAllTemplates(indexable as SitecoreIndexableItem);
 		}
 
 		private static List<string> GetAllTemplates(Item item)
 		{
-			Assert.ArgumentNotNull(item, "item");
-			Assert.IsNotNull(item.Template, "Item template not found.");
+            // SitecoreIndexableItem is not of type Sitecore.Data.Items.Item
+            if (item == null)
+            {
+                return new List<string>();
+            }
+
+            Assert.IsNotNull(item.Template, "Item template not found.");
 			var list = new List<string> { IdHelper.NormalizeGuid(item.TemplateID) };
 			RecurseTemplates(list, item.Template);
 			return list;
@@ -42,8 +48,11 @@ namespace Synthesis.ContentSearch.ComputedFields
 			foreach (var baseTemplateItem in template.BaseTemplates)
 			{
 				list.Add(IdHelper.NormalizeGuid(baseTemplateItem.ID));
-				if (baseTemplateItem.ID != TemplateIDs.StandardTemplate)
-					RecurseTemplates(list, baseTemplateItem);
+			    if (baseTemplateItem.ID != TemplateIDs.StandardTemplate)
+			    {
+                    RecurseTemplates(list, baseTemplateItem);
+                }
+					
 			}
 		}
 	}


### PR DESCRIPTION
SitecoreIndexableItem is not always of type Sitecore.Data.Items.Item (for example list items in List Manager). I have moved the null-check before the type cast, and skipping the computed field if type cast fails (returning empty list).