### PR TITLE
Added functionality to make rendered fields uneditable in EE

### DIFF
--- a/Source/Synthesis.Mvc/Extensions/DateFields.cs
+++ b/Source/Synthesis.Mvc/Extensions/DateFields.cs
@@ -19,12 +19,26 @@ namespace Synthesis.Mvc.Extensions
 	{
 		public static IHtmlString Render(this IDateTimeField field)
 		{
-			return Render(field, "g");
+			return Render(field, "g", true);
+		}
+
+		public static IHtmlString Render(this IDateTimeField field, bool editable)
+		{
+			return Render(field, "g", editable);
 		}
 
 		public static IHtmlString Render(this IDateTimeField field, string format)
 		{
-			return Render(field, x => { x.Format = format; });
+			return Render(field, format, true);
+		}
+
+		public static IHtmlString Render(this IDateTimeField field, string format, bool editable)
+		{
+			return Render(field, x =>
+			{
+				x.Format = format;
+				x.DisableWebEditing = !editable;
+			});
 		}
 
 		public static IHtmlString Render(IDateTimeField field, Action<Date> parameters)

--- a/Source/Synthesis.Mvc/Extensions/HyperlinkFields.cs
+++ b/Source/Synthesis.Mvc/Extensions/HyperlinkFields.cs
@@ -18,7 +18,7 @@ namespace Synthesis.Mvc.Extensions
 	/// </summary>
 	public static class HyperlinkFields
 	{
-		public static IHtmlString Render(this IHyperlinkField field, string linkText = null, string cssClass = null)
+		public static IHtmlString Render(this IHyperlinkField field, string linkText = null, string cssClass = null, bool editable = true)
 		{
 			return Render(field, x =>
 			{
@@ -27,6 +27,9 @@ namespace Synthesis.Mvc.Extensions
 
 				if (cssClass != null)
 					x.CssClass = cssClass;
+
+				if(!editable)
+					x.DisableWebEditing = true;
 			});
 		}
 

--- a/Source/Synthesis.Mvc/Extensions/ImageFields.cs
+++ b/Source/Synthesis.Mvc/Extensions/ImageFields.cs
@@ -22,10 +22,22 @@ namespace Synthesis.Mvc.Extensions
 	{
 		public static IHtmlString Render(this IImageField field, string cssClass)
 		{
-			return Render(field, x => { x.CssClass = cssClass; });
+			return Render(field, true, cssClass);
+		}
+		public static IHtmlString Render(this IImageField field, bool editable)
+		{
+			return Render(field, editable, "");
+		}
+		public static IHtmlString Render(this IImageField field, bool editable, string cssClass)
+		{
+			return Render(field, x =>
+			{
+				x.CssClass = cssClass;
+				x.DisableWebEditing = !editable;
+			});
 		}
 
-		public static IHtmlString Render(this IImageField field, int? maxWidth = null, int? maxHeight = null, string cssClass = null)
+		public static IHtmlString Render(this IImageField field, int? maxWidth = null, int? maxHeight = null, string cssClass = null, bool editable = true)
 		{
 			return Render(field, x =>
 			{
@@ -34,6 +46,9 @@ namespace Synthesis.Mvc.Extensions
 
 				if (maxHeight.HasValue)
 					x.MaxHeight = maxHeight.Value;
+
+				if (!editable)
+					x.DisableWebEditing = true;
 
 				x.CssClass = cssClass;
 			});
@@ -53,11 +68,11 @@ namespace Synthesis.Mvc.Extensions
 			return new MvcHtmlString(string.Empty);
 		}
 
-		public static IHtmlString RenderDpiAware(this IImageField field, int? max1XWidth = null, int? max1XHeight = null, string cssClass = null, int maxScale = 2)
+		public static IHtmlString RenderDpiAware(this IImageField field, int? max1XWidth = null, int? max1XHeight = null, string cssClass = null, int maxScale = 2, bool editable = true)
 		{
 			if (Sitecore.Context.PageMode.IsExperienceEditor || maxScale == 1)
 			{
-				return Render(field, max1XWidth, max1XHeight, cssClass);
+				return Render(field, max1XWidth, max1XHeight, cssClass, editable);
 			}
 
 			if (field.HasValue)

--- a/Source/Synthesis.Mvc/Extensions/NumberFields.cs
+++ b/Source/Synthesis.Mvc/Extensions/NumberFields.cs
@@ -20,9 +20,18 @@ namespace Synthesis.Mvc.Extensions
 			return Render(field, "g");
 		}
 
+		public static IHtmlString Render(this IIntegerField field, bool editable)
+		{
+			return Render(field, "g", editable);
+		}
 		public static IHtmlString Render(this IIntegerField field, string format)
 		{
-			if (Sitecore.Context.PageMode.IsExperienceEditor)
+			return Render(field, format, true);
+		}
+
+		public static IHtmlString Render(this IIntegerField field, string format, bool editable)
+		{
+			if (Sitecore.Context.PageMode.IsExperienceEditor && editable)
 			{
 				return new HtmlString(field.RenderedValue);
 			}
@@ -40,9 +49,19 @@ namespace Synthesis.Mvc.Extensions
 			return Render(field, "g");
 		}
 
+		public static IHtmlString Render(this INumericField field, bool editable)
+		{
+			return Render(field, "g", editable);
+		}
+
 		public static IHtmlString Render(this INumericField field, string format)
 		{
-			if (Sitecore.Context.PageMode.IsExperienceEditor)
+			return Render(field, format, true);
+		}
+
+		public static IHtmlString Render(this INumericField field, string format, bool editable)
+		{
+			if (Sitecore.Context.PageMode.IsExperienceEditor && editable)
 			{
 				return new HtmlString(field.RenderedValue);
 			}


### PR DESCRIPTION
added the `editable` overload functionality that was in TextFields to the `.Render()` methods of other field types